### PR TITLE
Speed up bunnyhop animation

### DIFF
--- a/lua_files/jokers.lua
+++ b/lua_files/jokers.lua
@@ -4716,6 +4716,7 @@ bunnyhop.calculate = function(self, card, context)
 			end
 		end
 		return {
+			delay = 0.2,
 			message = localize('k_upgrade_ex'),
 			card = card,
 			colour = G.C.CHIPS


### PR DESCRIPTION
This speeds up Bunny Hop's upgrade text to be as fast/short as vanilla Ramen. Very noticeable because Bunny Hop does its thing on every single discard. _(I have a bunny hop run going on, it got on my nerves)_

_(awesome mod btw! don't think I wrote that on any bug report so I'm saying it here (I also made [pages for it on the modded balatro wiki](https://balatromods.miraheze.org/wiki/Celeste_Card_Collection)))_